### PR TITLE
Не создавать тур без выбора места старта

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -22,6 +22,11 @@
                 <b style="color: white"> Контакты </b>
               </router-link>
             </a-col>
+              <a-col class="d-flex align-center direction-column">
+                <a href="https://promo.plpo.ru" target="_blank">
+                  <b style="color: white"> Партнерам </b>
+                </a>
+              </a-col>
           </a-row>
       
         </a-col>

--- a/src/views/CreateTripNoHelp.vue
+++ b/src/views/CreateTripNoHelp.vue
@@ -129,6 +129,13 @@ function submit() {
     return
   }
 
+  if (!form.startLocation || !form.startLocation.coordinates?.length) {
+    message.config({ duration: 2, top: "70vh" });
+    message.error("Выберите место старта из списка");
+    submitCount.value = 0
+    return
+  }
+
   const regexEmoji = /(?![*#0-9]+)[\p{Emoji}\p{Emoji_Modifier}\p{Emoji_Component}\p{Emoji_Modifier_Base}\p{Emoji_Presentation}]/gu
   const regexSpaces = /[\n\r\s\t]+/g
 
@@ -273,6 +280,10 @@ const handlePlacesSearch = async (val) => {
 
 }
 watch(locationSearchRequest, async (newValue, oldValue) => {
+  if (form.startLocation?.name !== newValue) {
+    form.startLocation = null
+  }
+
   if (newValue.trim().length > 2 && newValue.length > oldValue.length) {
     var url = "https://suggestions.dadata.ru/suggestions/api/4_1/rs/suggest/address";
 
@@ -389,7 +400,11 @@ let formSchema = yup.object({
   fromAge: yup.string().required("заполните поле"),
   offer: yup.string().required("заполните поле"),
   tripRoute: yup.string().required("заполните поле"),
-  // startLocation: yup.string().required("заполните поле"),
+  startLocation: yup.string().required("заполните поле").test(
+    "start-location-selected",
+    "выберите место из списка",
+    () => !!form.startLocation?.coordinates?.length
+  ),
   // returnConditions: yup.string().required("заполните поле"),
   notNecessarily: yup.string(),
   tripRegion: yup.string().required("заполните поле"),

--- a/src/views/TripInfoPage.vue
+++ b/src/views/TripInfoPage.vue
@@ -606,7 +606,7 @@ onMounted(async () => {
                                     <div
                                         v-if="item.limit - (isNaN(customersByCostType[item.first]) ? 0 : customersByCostType[item.first]) !== 0">
                                         {{ item.first }}: <b>{{ item.price }} руб.</b>
-                                        <span>
+                                        <span v-if="item.limit">
                                             <span> | мест - {{
                                                 item.limit - (isNaN(customersByCostType[item.first]) ? 0 :
                                                     customersByCostType[item.first])


### PR DESCRIPTION
## Что изменено
- Добавлена обязательная валидация поля startLocation.
- Добавлена проверка в submit: создание тура блокируется без выбранного места старта.
- При ручном изменении текста в поле старта выбранная геолокация сбрасывается.

## Зачем
Исправляет сценарий, когда можно было создать тур без корректно выбранного места старта.

## Проверка
- Нельзя отправить форму без выбора места старта из автоподсказки.
- После редактирования текста нужно выбрать место заново.
- При корректном выборе форма отправляется штатно.